### PR TITLE
Use ZIP compression for cached frameworks

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,6 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", .branch("main")),
         .package(url: "https://github.com/apple/swift-tools-support-core", .upToNextMajor(from: "0.2.0")),
-
     ],
     targets: [
         .executableTarget(

--- a/Sources/TorinoCore/Services/ArchiveService.swift
+++ b/Sources/TorinoCore/Services/ArchiveService.swift
@@ -1,0 +1,51 @@
+import Foundation
+import TSCBasic
+
+protocol ArchiveServicing {
+    func archive(files: [RelativePath], basePath: AbsolutePath, destination: AbsolutePath) throws
+    func unarchive(from path: AbsolutePath, destination: AbsolutePath) throws
+}
+
+final class ZipService: ArchiveServicing {
+    private struct ShellError: Error {
+        let code: Int32
+    }
+    
+    // MARK: - Public interface
+    
+    func archive(files: [RelativePath], basePath: AbsolutePath, destination: AbsolutePath) throws {
+        do {
+            try shell(
+                [
+                    "zip", "-ruq",
+                    destination.pathString,
+                ] + files.map(\.pathString),
+                cwd: basePath
+            )
+        } catch let error as ShellError {
+            if error.code != 12 { // zip has nothing to do
+                throw error
+            }
+        }
+    }
+    
+    func unarchive(from path: AbsolutePath, destination: AbsolutePath) throws {
+        try shell(["unzip", "-ouqq", path.pathString], cwd: destination)
+    }
+    
+    // MARK: - Private helpers
+
+    private func shell(_ args: [String], cwd: AbsolutePath? = nil) throws {
+        let task = Process()
+        task.launchPath = "/usr/bin/env"
+        task.currentDirectoryURL = cwd?.asURL
+        task.arguments = args
+        task.launch()
+        task.waitUntilExit()
+        
+        if task.terminationStatus != 0 {
+            throw ShellError(code: task.terminationStatus)
+        }
+    }
+
+}

--- a/Sources/TorinoCore/Services/DependenciesDownloader.swift
+++ b/Sources/TorinoCore/Services/DependenciesDownloader.swift
@@ -34,22 +34,14 @@ struct LocalDependenciesDownloader: DependenciesDownloading {
         try? fileSystem.createDirectory(buildDir, recursive: true)
         
         try dependencies.forEach { dependency in
-            let cacheDir = pathProvider.cacheDir(
+            let cachePath = pathProvider.cacheDir(
                 dependency: dependency.name,
                 version: dependency.version
             )
             
-            guard fileSystem.exists(cacheDir) else { return }
+            guard fileSystem.exists(cachePath) else { return }
             
-            let cachedFiles = try fileSystem.getDirectoryContents(cacheDir)
-            
-            cachedFiles.forEach { path in
-                let destination = buildDir.appending(component: path)
-                let cached = cacheDir.appending(component: path)
-                
-                try? fileSystem.removeFileTree(destination)
-                try? fileSystem.copy(from: cached, to: destination)
-            }
+            try shell("unzip", cachePath.pathString, cwd: buildDir)
         }
     }
 }

--- a/Sources/TorinoCore/Services/DependenciesDownloader.swift
+++ b/Sources/TorinoCore/Services/DependenciesDownloader.swift
@@ -41,7 +41,7 @@ struct LocalDependenciesDownloader: DependenciesDownloading {
             
             guard fileSystem.exists(cachePath) else { return }
             
-            try shell("unzip", cachePath.pathString, cwd: buildDir)
+            try shell("unzip", "-ouqq", cachePath.pathString, cwd: buildDir)
         }
     }
 }

--- a/Sources/TorinoCore/Services/DependenciesDownloader.swift
+++ b/Sources/TorinoCore/Services/DependenciesDownloader.swift
@@ -15,15 +15,18 @@ protocol DependenciesDownloading {
 }
 
 struct LocalDependenciesDownloader: DependenciesDownloading {
+    private let archiveService: ArchiveServicing
     private let fileSystem: FileSystem
     private let pathProvider: PathProviding
     
     // MARK: - Initializers
     
     init(
+        archiveService: ArchiveServicing = ZipService(),
         fileSystem: FileSystem = localFileSystem,
         pathProvider: PathProviding
     ) {
+        self.archiveService = archiveService
         self.fileSystem = fileSystem
         self.pathProvider = pathProvider
     }
@@ -41,7 +44,10 @@ struct LocalDependenciesDownloader: DependenciesDownloading {
             
             guard fileSystem.exists(cachePath) else { return }
             
-            try shell("unzip", "-ouqq", cachePath.pathString, cwd: buildDir)
+            try archiveService.unarchive(
+                from: cachePath,
+                destination: buildDir
+            )
         }
     }
 }

--- a/Sources/TorinoCore/Services/DependenciesUploader.swift
+++ b/Sources/TorinoCore/Services/DependenciesUploader.swift
@@ -41,7 +41,7 @@ struct LocalDependenciesUploader: DependenciesUploading {
                 "zip", "-r",
                 cachePath.pathString,
                 dependency.versionFile.relative(to: buildDir).pathString, ";"
-            ] + paths, cwd: buildDir.asURL)
+            ] + paths, cwd: buildDir)
         }
     }
 }
@@ -50,14 +50,14 @@ struct ShellError: Error {
     let code: Int32
 }
 
-func shell(_ args: String..., cwd: URL?) throws {
+func shell(_ args: String..., cwd: AbsolutePath?) throws {
     try shell(Array(args), cwd: cwd)
 }
 
-func shell(_ args: [String], cwd: URL?) throws {
+func shell(_ args: [String], cwd: AbsolutePath?) throws {
     let task = Process()
     task.launchPath = "/usr/bin/env"
-    task.currentDirectoryURL = cwd
+    task.currentDirectoryURL = cwd?.asURL
     task.arguments = args
     task.launch()
     task.waitUntilExit()

--- a/Sources/TorinoCore/Services/DependenciesUploader.swift
+++ b/Sources/TorinoCore/Services/DependenciesUploader.swift
@@ -32,16 +32,21 @@ struct LocalDependenciesUploader: DependenciesUploading {
                 version: dependency.version
             )
         
-            try? fileSystem.removeFileTree(cachePath)
             try? fileSystem.createDirectory(cachePath.parentDirectory, recursive: true)
         
             let paths = dependency.frameworks.map { $0.path.relative(to: buildDir).pathString }
             
-            try shell([
-                "zip", "-r",
-                cachePath.pathString,
-                dependency.versionFile.relative(to: buildDir).pathString, ";"
-            ] + paths, cwd: buildDir)
+            do {
+                try shell([
+                    "zip", "-ruq",
+                    cachePath.pathString,
+                    dependency.versionFile.relative(to: buildDir).pathString,
+                ] + paths, cwd: buildDir)
+            } catch let error as ShellError {
+                if error.code != 12 { // zip has nothing to do
+                    throw error
+                }
+            }
         }
     }
 }

--- a/Sources/TorinoCore/Services/PathProvider.swift
+++ b/Sources/TorinoCore/Services/PathProvider.swift
@@ -42,7 +42,7 @@ struct CarthagePathProvider: PathProviding {
     }
     
     func cacheDir(dependency: String, version: String) -> AbsolutePath {
-        _cacheDir.appending(components: dependency, version)
+        _cacheDir.appending(component: dependency + "-" + version + ".zip")
     }
     
     func lockfile() -> AbsolutePath {


### PR DESCRIPTION
To reduce disk space usage, store cached frameworks as ZIP archives. This will also be a preparation for remote cache support.