### PR TITLE
Basic improvements

### DIFF
--- a/Sources/GCP_Remote/Extensions/URLSessionExtensions.swift
+++ b/Sources/GCP_Remote/Extensions/URLSessionExtensions.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 extension URLSession {
+    static let torino = URLSession(configuration: .ephemeral)
+    
     func syncDataTask(for request: URLRequest) throws -> (Data?, URLResponse?) {
         let semaphore = DispatchSemaphore(value: 0)
         

--- a/Sources/GCP_Remote/Model/GoogleClaims.swift
+++ b/Sources/GCP_Remote/Model/GoogleClaims.swift
@@ -3,11 +3,16 @@ import SwiftJWT
 
 /// Struct that is used for generating second part of JWT token
 struct GoogleClaims: Claims {
+    enum Scope: String, Codable {
+        case readOnly = "https://www.googleapis.com/auth/devstorage.read_only"
+        case readWrite = "https://www.googleapis.com/auth/devstorage.read_write"
+    }
+    
     /// Service account email
     let iss: String
 
     /// Required scope
-    let scope: String
+    let scope: Scope
 
     /// Desired auth endpoint
     let aud: URL
@@ -17,22 +22,10 @@ struct GoogleClaims: Claims {
 
     /// Issued at date timestamp
     let iat: Int
-
-    private init(iss: String, scope: String, exp: Int, iat: Int) {
-        self.iss = iss
-        self.scope = scope
-        self.aud = URL(string: "https://oauth2.googleapis.com/token")!
-        self.exp = exp
-        self.iat = iat
-    }
 }
 
 extension GoogleClaims {
-    static func readOnly(iss: String, exp: Int, iat: Int) -> GoogleClaims {
-        .init(iss: iss, scope: "https://www.googleapis.com/auth/devstorage.read_only", exp: exp, iat: iat)
-    }
-
-    static func readWrite(iss: String, exp: Int, iat: Int) -> GoogleClaims {
-        .init(iss: iss, scope: "https://www.googleapis.com/auth/devstorage.read_write", exp: exp, iat: iat)
+    init(serviceAccount: ServiceAccount, scope: Scope, exp: Int, iat: Int) {
+        self.init(iss: serviceAccount.clientEmail, scope: scope, aud: serviceAccount.tokenURL, exp: exp, iat: iat)
     }
 }

--- a/Sources/GCP_Remote/Model/ServiceAccount.swift
+++ b/Sources/GCP_Remote/Model/ServiceAccount.swift
@@ -5,6 +5,7 @@ public struct ServiceAccount: Decodable {
     enum CodingKeys: String, CodingKey {
         case clientEmail = "client_email"
         case privateKey = "private_key"
+        case tokenURL = "token_uri"
     }
     
     /// Email associated with the service account
@@ -13,10 +14,6 @@ public struct ServiceAccount: Decodable {
     /// Private key used to generate JWT token
     let privateKey: String
     
-    // MARK: - Initializers
-    
-    init(clientEmail: String, privateKey: String) {
-        self.clientEmail = clientEmail
-        self.privateKey = privateKey
-    }
+    /// URL for fetching OAuth token
+    let tokenURL: URL
 }

--- a/Sources/GCP_Remote/Services/AuthAPIService.swift
+++ b/Sources/GCP_Remote/Services/AuthAPIService.swift
@@ -19,7 +19,11 @@ public struct AuthAPIService: AuthAPIServicing {
     
     // MARK: - Initializers
     
-    public init(session: URLSession = .shared) {
+    public init() {
+        self.init(session: .torino)
+    }
+    
+    public init(session: URLSession) {
         self.session = session
     }
     
@@ -51,12 +55,9 @@ public struct AuthAPIService: AuthAPIServicing {
         return (try? jwt.sign(using: signer)) ?? ""
     }
     
-    private func claims(serviceAccount: ServiceAccount, validFor interval: TimeInterval, readOnly: Bool) -> GoogleClaims {
+    private func claims(serviceAccount sa: ServiceAccount, validFor interval: TimeInterval, readOnly: Bool) -> GoogleClaims {
         let now = Int(Date().timeIntervalSince1970)
-        
-        if readOnly {
-            return GoogleClaims.readOnly(iss: serviceAccount.clientEmail, exp: now + Int(interval), iat: now)
-        }
-        return GoogleClaims.readWrite(iss: serviceAccount.clientEmail, exp: now + Int(interval), iat: now)
+
+        return .init(serviceAccount: sa, scope: readOnly ? .readOnly : .readWrite, exp: now + Int(interval), iat: now)
     }
 }

--- a/Sources/GCP_Remote/Services/GCPDownloader.swift
+++ b/Sources/GCP_Remote/Services/GCPDownloader.swift
@@ -17,7 +17,15 @@ public struct GCPDownloader: GCPDownloading {
     
     public init(
         authAPI: AuthAPIServicing = AuthAPIService(),
-        session: URLSession = .shared,
+        fileSystem: FileSystem = localFileSystem,
+        config: GCPConfig
+    ) {
+        self.init(authAPI: authAPI, session: .torino, fileSystem: fileSystem, config: config)
+    }
+    
+    public init(
+        authAPI: AuthAPIServicing = AuthAPIService(),
+        session: URLSession,
         fileSystem: FileSystem = localFileSystem,
         config: GCPConfig
     ) {

--- a/Sources/GCP_Remote/Services/GCPUploader.swift
+++ b/Sources/GCP_Remote/Services/GCPUploader.swift
@@ -14,7 +14,18 @@ public struct GCPUploader: GCPUploading {
     
     // MARK: - Initializers
     
-    public init(authAPI: AuthAPIServicing = AuthAPIService(), session: URLSession = .shared, config: GCPConfig) {
+    public init(
+        authAPI: AuthAPIServicing = AuthAPIService(),
+        config: GCPConfig
+    ) {
+        self.init(authAPI: authAPI, session: .torino, config: config)
+    }
+    
+    public init(
+        authAPI: AuthAPIServicing = AuthAPIService(),
+        session: URLSession,
+        config: GCPConfig
+    ) {
         self.authAPI = authAPI
         self.session = session
         self.config = config


### PR DESCRIPTION
- add `Scope` enum to `GoogleClaims`
- use `token_uri` from GCP `ServiceAccount` for fetching OAuth token
- use customized ephemeral `URLSession`