### PR TITLE
Check MD5 hash before upload

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/vapor/jwt-kit",
         "state": {
           "branch": null,
-          "revision": "5f9c44d4c196cc06c3fc601f279169f121d6f62d",
-          "version": "4.4.0"
+          "revision": "ca2edf69a613f3d89354114f56cfd9921d2727d5",
+          "version": "4.2.6"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "e394bf350e38cb100b6bc4172834770ede1b7232",
-          "version": "1.0.3"
+          "revision": "d2930e8fcf9c33162b9fcc1d522bc975e2d4179b",
+          "version": "1.0.1"
         }
       },
       {
@@ -24,17 +24,8 @@
         "repositoryURL": "https://github.com/apple/swift-crypto.git",
         "state": {
           "branch": null,
-          "revision": "a8911e0fadc25aef1071d582355bd1037a176060",
-          "version": "2.0.4"
-        }
-      },
-      {
-        "package": "swift-system",
-        "repositoryURL": "https://github.com/apple/swift-system.git",
-        "state": {
-          "branch": null,
-          "revision": "836bc4557b74fe6d2660218d56e3ce96aff76574",
-          "version": "1.1.1"
+          "revision": "127d3745c37b5705e4bc8d16c7951c48dcc3332c",
+          "version": "2.0.0"
         }
       },
       {
@@ -42,8 +33,8 @@
         "repositoryURL": "https://github.com/apple/swift-tools-support-core",
         "state": {
           "branch": null,
-          "revision": "b7667f3e266af621e5cc9c77e74cacd8e8c00cb4",
-          "version": "0.2.5"
+          "revision": "f9bbd6b80d67408021576adf6247e17c2e957d92",
+          "version": "0.2.4"
         }
       }
     ]

--- a/Sources/GCP_Remote/Model/Metadata.swift
+++ b/Sources/GCP_Remote/Model/Metadata.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public struct Metadata: Codable {
+    public let crc32c: String
+    public let etag: String
+    public let md5Hash: String
+}

--- a/Sources/GCP_Remote/Services/GCPAPIService.swift
+++ b/Sources/GCP_Remote/Services/GCPAPIService.swift
@@ -7,8 +7,8 @@ public protocol GCPAPIServicing {
         token: AccessToken
     ) async throws -> Data
     
-    func uploadData(
-        _ data: Data,
+    func upload(
+        file: URL,
         object: String,
         bucket: String,
         token: AccessToken
@@ -54,8 +54,8 @@ public final class GCPAPIService: GCPAPIServicing {
         return try await session.data(request: request).0
     }
     
-    public func uploadData(
-        _ data: Data,
+    public func upload(
+        file: URL,
         object: String,
         bucket: String,
         token: AccessToken
@@ -73,9 +73,8 @@ public final class GCPAPIService: GCPAPIServicing {
         token.addToRequest(&request)
         request.setValue("application/zip", forHTTPHeaderField: "Content-Type")
         request.httpMethod = "POST"
-        request.httpBody = data
         
-        _ = try await session.data(request: request)
+        try await session.upload(request: request, fromFile: file)
     }
     
     // MARK: - Private helpers

--- a/Sources/GCP_Remote/Services/GCPUploader.swift
+++ b/Sources/GCP_Remote/Services/GCPUploader.swift
@@ -62,8 +62,8 @@ public struct GCPUploader: GCPUploading {
             do {
                 request.httpBody = try Data(contentsOf: localPath.asURL)
                 
-                try await gcpAPI.uploadData(
-                    try Data(contentsOf: localPath.asURL),
+                try await gcpAPI.upload(
+                    file: localPath.asURL,
                     object: remotePath,
                     bucket: config.bucket,
                     token: token


### PR DESCRIPTION
So far we always uploaded all dependencies. After merging this PR we will first try to fetch object's MD5 hash, compare it with what is to be uploaded and upload it only if binary has changed.