### PR TITLE
Fix pre-upload hash check

### DIFF
--- a/Sources/GCP_Remote/Model/GoogleClaims.swift
+++ b/Sources/GCP_Remote/Model/GoogleClaims.swift
@@ -5,7 +5,7 @@ import JWTKit
 struct GoogleClaims: JWTPayload {
     enum Scope: String, Codable {
         case readOnly = "https://www.googleapis.com/auth/devstorage.read_only"
-        case readWrite = "https://www.googleapis.com/auth/devstorage.read_write"
+        case readWrite = "https://www.googleapis.com/auth/devstorage.full_control"
     }
     
     /// Service account email

--- a/Sources/GCP_Remote/Model/Metadata.swift
+++ b/Sources/GCP_Remote/Model/Metadata.swift
@@ -1,7 +1,9 @@
 import Foundation
 
 public struct Metadata: Codable {
-    public let crc32c: String
-    public let etag: String
-    public let md5Hash: String
+    public struct CustomMetadata: Codable {
+        public let carthageHash: String?
+    }
+    
+    public let metadata: CustomMetadata?
 }

--- a/Sources/GCP_Remote/Model/UploadItem.swift
+++ b/Sources/GCP_Remote/Model/UploadItem.swift
@@ -1,0 +1,20 @@
+import Foundation
+import TSCBasic
+
+public struct UploadItem {
+    public let localFile: AbsolutePath
+    public let remotePath: String
+    public let hash: String
+    
+    // MARK: - Initializers
+    
+    public init(
+        localFile: AbsolutePath,
+        remotePath: String,
+        hash: String
+    ) {
+        self.localFile = localFile
+        self.remotePath = remotePath
+        self.hash = hash
+    }
+}

--- a/Sources/GCP_Remote/Services/GCPAPIService.swift
+++ b/Sources/GCP_Remote/Services/GCPAPIService.swift
@@ -19,6 +19,13 @@ public protocol GCPAPIServicing {
         bucket: String,
         token: AccessToken
     ) async throws -> Metadata
+    
+    func updateMetadata(
+        _ metadata: Metadata,
+        object: String,
+        bucket: String,
+        token: AccessToken
+    ) async throws
 }
 
 public final class GCPAPIService: GCPAPIServicing {
@@ -99,6 +106,21 @@ public final class GCPAPIService: GCPAPIServicing {
             Metadata.self,
             from: session.data(request: request).0
         )
+    }
+    
+    public func updateMetadata(
+        _ metadata: Metadata,
+        object: String,
+        bucket: String,
+        token: AccessToken
+    ) async throws {
+        var request = URLRequest(url: .init(string: "https://storage.googleapis.com/storage/v1/b/\(bucket)/o/\(object.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed)!)")!)
+        token.addToRequest(&request)
+        request.httpMethod = "PATCH"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONEncoder().encode(metadata)
+        
+        try await session.data(request: request)
     }
     
     // MARK: - Private helpers

--- a/Sources/GCP_Remote/Services/GCPUploader.swift
+++ b/Sources/GCP_Remote/Services/GCPUploader.swift
@@ -80,6 +80,14 @@ public struct GCPUploader: GCPUploading {
                     bucket: config.bucket,
                     token: token
                 )
+                
+                try await gcpAPI.updateMetadata(
+                    .init(metadata: .init(carthageHash: localHash)),
+                    object: remotePath,
+                    bucket: config.bucket,
+                    token: token
+                )
+                
                 logger.info("Successfully uploaded dependency", name)
             } catch {
                 logger.info("Unable to upload dependency", name)

--- a/Sources/GCP_Remote/Services/GCPUploader.swift
+++ b/Sources/GCP_Remote/Services/GCPUploader.swift
@@ -44,41 +44,31 @@ public struct GCPUploader: GCPUploading {
         try await items.asyncForEach {
             let localPath = $0.localFile
             let remotePath = $0.remotePath
+            let localHash = $0.hash
             let name = localPath.basenameWithoutExt
             
             logger.info("Uploading dependency", name)
             
             do {
-                let existingMetadata: Metadata?
+                let remoteHash: String?
                 
                 do {
-                    let metadata = try await gcpAPI.metadata(
+                    remoteHash = try await gcpAPI.metadata(
                         object: remotePath,
                         bucket: config.bucket,
                         token: token
-                    )
-                    existingMetadata = metadata
-                    logger.debug(
-                        "Existing MD5 for dependency",
-                        name,
-                        "is",
-                        metadata.md5Hash
-                    )
+                    ).metadata?.carthageHash
                 } catch {
-                    existingMetadata = nil
+                    remoteHash = nil
                     logger.debug("Unable to fetch existing metadata")
                     logger.debug(error)
                 }
                 
-                if let currentMD5 = existingMetadata?.md5Hash,
-                    let data = try? Data(contentsOf: localPath.asURL) {
-                    let md5 = Data(Insecure.MD5.hash(data: data))
-                        .base64EncodedString()
+                if let currentHash = remoteHash {
+                    logger.debug("Comparing hash for dependendency", name)
+                    logger.debug("Local:", localHash, "Remote:", remoteHash ?? "(nil)")
                     
-                    logger.debug("Comparing MD5 hash for dependendency", name)
-                    logger.debug("Local:", md5, "Remote:", currentMD5)
-                    
-                    if currentMD5 == md5 {
+                    if currentHash == localHash {
                         logger.info("Dependency " + name + " has not changed, skipping upload")
                         return
                     }

--- a/Sources/GCP_Remote/Services/GCPUploader.swift
+++ b/Sources/GCP_Remote/Services/GCPUploader.swift
@@ -1,9 +1,6 @@
 import Foundation
-import TSCBasic
 import Logger
 import CryptoKit
-
-public typealias UploadItem = (localFile: AbsolutePath, remotePath: String)
 
 public protocol GCPUploading {
     func upload(items: [UploadItem]) async throws
@@ -44,7 +41,9 @@ public struct GCPUploader: GCPUploading {
             readOnly: false
         )
         
-        try await items.asyncForEach { localPath, remotePath in
+        try await items.asyncForEach {
+            let localPath = $0.localFile
+            let remotePath = $0.remotePath
             let name = localPath.basenameWithoutExt
             
             logger.info("Uploading dependency", name)

--- a/Sources/TorinoCore/Model/Dependency.swift
+++ b/Sources/TorinoCore/Model/Dependency.swift
@@ -11,4 +11,5 @@ public struct Dependency {
     public let version: String
     public let frameworks: [Container]
     public let versionFile: AbsolutePath
+    public let hash: String
 }

--- a/Sources/TorinoCore/Services/DependenciesLoader.swift
+++ b/Sources/TorinoCore/Services/DependenciesLoader.swift
@@ -57,7 +57,8 @@ public struct CarthageDependenciesLoader: DependenciesLoading {
                 frameworks: $0.versionFile.allContainers.map {
                     .init(name: $0, path: buildDir.appending(component: $0))
                 },
-                versionFile: $0.path
+                versionFile: $0.path,
+                hash: $0.versionFile.combinedHash
             )
         }
     }

--- a/Sources/TorinoCore/Services/DependenciesUploader.swift
+++ b/Sources/TorinoCore/Services/DependenciesUploader.swift
@@ -50,10 +50,14 @@ struct LocalDependenciesUploader: DependenciesUploading {
                 destination: cachePath
             )
             
-            uploadItems.append((cachePath, pathProvider.remoteCachePath(
-                dependency: dependency.name,
-                version: dependency.version
-            )))
+            uploadItems.append(.init(
+                localFile: cachePath,
+                remotePath: pathProvider.remoteCachePath(
+                    dependency: dependency.name,
+                    version: dependency.version
+                ),
+                hash: "" // TODO: Implement
+            ))
         }
         
         if let gcpUploader = gcpUploader {

--- a/Sources/TorinoCore/Services/DependenciesUploader.swift
+++ b/Sources/TorinoCore/Services/DependenciesUploader.swift
@@ -56,7 +56,7 @@ struct LocalDependenciesUploader: DependenciesUploading {
                     dependency: dependency.name,
                     version: dependency.version
                 ),
-                hash: "" // TODO: Implement
+                hash: dependency.hash
             ))
         }
         


### PR DESCRIPTION
As ZIP hashes differ based on who builds concrete framework, we use custom metadata on GCP to store hashes from Carthage to work around this issue.