### PR TITLE
🐛 Do not upload empty dependencies

### DIFF
--- a/Sources/TorinoCore/Model/VersionFile.swift
+++ b/Sources/TorinoCore/Model/VersionFile.swift
@@ -28,10 +28,11 @@ public struct VersionFile: Decodable {
             .base64EncodedString()
     }
     
-    private var allFrameworks: [Framework] {
+    public var allFrameworks: [Framework] {
         [iOS, macOS, tvOS, watchOS]
             .compactMap { $0 }
             .flatMap { $0 }
+            .filter { ($0.container ?? "").isEmpty == false }
     }
 }
 

--- a/Sources/TorinoCore/Services/DependenciesLoader.swift
+++ b/Sources/TorinoCore/Services/DependenciesLoader.swift
@@ -48,7 +48,7 @@ public struct CarthageDependenciesLoader: DependenciesLoading {
                     versionFile: try jsonDecoder.decode(VersionFile.self, from: data),
                     path: versionFilePath.path
                 )
-            }
+            }.filter { $0.versionFile.allFrameworks.isEmpty == false }
         
         return versionFiles.map {
             Dependency(


### PR DESCRIPTION
If we have empty version file (no platform has any XCFramework = version file doesn't contain any `container`) then do not upload it at all.